### PR TITLE
Resend API Key: Stop hardcoding it

### DIFF
--- a/src/lib/sendEmail.ts
+++ b/src/lib/sendEmail.ts
@@ -2,7 +2,7 @@ import { Resend } from "resend";
 
 export const sendEmail = async (name: string, email: string, htmlContent: string, from: string, to: string, key: string) => {
     // TODO: Pass via env
-    const resend = new Resend("re_aTWSbhYi_82ZRZnKugtapzsJs7uXfebYe");
+    const resend = new Resend(key);
     const sendResend = await resend.emails.send({
         from: from,
         replyTo: email as string,


### PR DESCRIPTION
This PR seems simple. The meat of the matter is in how we provision secrets to cloudflare. Essentially, secrets are provisioned at deploy-time, and will not apply after that.

So, in order for the worker to be instantiated with the correct API key, first we need to provision the key, THEN do the next deployment.