### PR TITLE
Fix canonical html

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -25,7 +25,7 @@ let openGraph = {
 	<head>
 		<GoogleAnayltics />
 		<SEO
-			canonical={new URL(Astro.url.pathname, Astro.site)}
+			canonical={new URL(Astro.url.pathname.replace(/\.html$/, ""), Astro.site)}
 			title={title}
 			titleTemplate="Alpenglow Guiding | %s"
 			description={description}

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -25,6 +25,7 @@ let openGraph = {
 	<head>
 		<GoogleAnayltics />
 		<SEO
+			canonical={new URL(Astro.url.pathname, Astro.site)}
 			title={title}
 			titleTemplate="Alpenglow Guiding | %s"
 			description={description}


### PR DESCRIPTION
I noticed all canonical links included .html since changing from directory to file mode. This addresses that.