### PR TITLE
Remove display=grid from articles

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -20,9 +20,6 @@ article #content img {
     place-self: center;
 }
 
-article p {
-    display: grid;
-}
 
 a {
     transition: color 0.2s ease-in-out;


### PR DESCRIPTION
This was causing inline links to display funny. And it wasn't helping display the photos side-by-side